### PR TITLE
Add Unit Test Suites for DashboardController and ProfileController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.7.tgz",
-      "integrity": "sha512-4wJTtBJsbvjLIzXl+Qj6DYHv4J7abotuXyk7bes5erL79y+KBT61LulL56SqilzmNnHOAVbXcSXOn9S2aWUn6A==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.8.tgz",
+      "integrity": "sha512-BQ/MIXcO2TjLVR9ZCN1MRQqijgCI7taueLdxowLS9UmAHbN7iZcQt307NTC6SFt8uVJg2CrLanD60M/Pr0ZMoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1610,13 +1610,13 @@
         "cli-table3": "0.6.5",
         "commander": "4.1.1",
         "fork-ts-checker-webpack-plugin": "9.0.2",
-        "glob": "10.4.2",
+        "glob": "10.4.5",
         "inquirer": "8.2.6",
         "node-emoji": "1.11.0",
         "ora": "5.4.1",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "4.2.0",
-        "tsconfig-paths-webpack-plugin": "4.1.0",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "5.6.3",
         "webpack": "5.96.1",
         "webpack-node-externals": "3.0.0"
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001680",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+      "version": "1.0.30001683",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
+      "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
       "dev": true,
       "funding": [
         {
@@ -5356,9 +5356,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5370,9 +5370,6 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6918,9 +6915,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.14",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.14.tgz",
-      "integrity": "sha512-sexvAfwcW1Lqws4zFp8heAtAEXbEDnvkYCEGzvOoMgZR7JhXo/IkE9MkkGACgBed5fWqh3ShBGnJBdDnU9N8EQ==",
+      "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.15.tgz",
+      "integrity": "sha512-M7+rtYi9l5RvMmHyjyoF3BHHUpXTYdJ0PezZGHNs0GyW1lO+K7jxlXpbdIb7a56h0nqLYdjIw+E+z0ciGaJP7g==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -9567,14 +9564,15 @@
       }
     },
     "node_modules/tsconfig-paths-webpack-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
-      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
         "tsconfig-paths": "^4.1.2"
       },
       "engines": {

--- a/src/UI/dashboard.controller.spec.ts
+++ b/src/UI/dashboard.controller.spec.ts
@@ -1,0 +1,414 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardController } from './dashboard.controller';
+import { UserService } from '../user/user.service';
+import { IntervalService } from '../interval/interval.service';
+import { GoalService } from '../goal/goal.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../roles/roles.guard';
+import { ForbiddenException } from '@nestjs/common';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  let mockUserService: Partial<UserService>;
+  let mockIntervalService: Partial<IntervalService>;
+  let mockGoalService: Partial<GoalService>;
+
+  beforeEach(async () => {
+    mockUserService = {
+      findAll: jest.fn().mockResolvedValue([
+        { id: 1, email: 'user1@email.com', role: 'user' },
+        { id: 2, email: 'admin@email.com', role: 'admin' },
+      ]),
+      findById: jest
+        .fn()
+        .mockResolvedValue({ id: 1, email: 'user1@email.com' }),
+      update: jest
+        .fn()
+        .mockResolvedValue({ id: 1, email: 'updated@email.com' }),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockIntervalService = {
+      findAllWithUsers: jest
+        .fn()
+        .mockResolvedValue([
+          { id: 1, startDate: new Date(), endDate: new Date(), userId: 1 },
+        ]),
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+      update: jest.fn().mockResolvedValue({
+        id: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({
+        id: 2,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+    };
+
+    mockGoalService = {
+      findAll: jest.fn().mockResolvedValue([
+        { id: 1, name: 'Goal 1', intervalId: 1 },
+        { id: 2, name: 'Goal 2', intervalId: 1 },
+      ]),
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        name: 'Goal 1',
+        intervalId: 1,
+      }),
+      update: jest.fn().mockResolvedValue({
+        id: 1,
+        name: 'Updated Goal',
+        intervalId: 1,
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({
+        id: 3,
+        name: 'New Goal',
+        intervalId: 1,
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [
+        { provide: UserService, useValue: mockUserService },
+        { provide: IntervalService, useValue: mockIntervalService },
+        { provide: GoalService, useValue: mockGoalService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getDashboard', () => {
+    it('should return data for dashboard', async () => {
+      const mockResponse = {
+        render: jest.fn(),
+      };
+      const mockRequest = {
+        user: { id: 1, role: 'admin' },
+      };
+
+      await controller.getDashboard(mockResponse as any, mockRequest as any);
+
+      expect(mockResponse.render).toHaveBeenCalledWith('dashboard', {
+        users: await mockUserService.findAll(),
+        intervals: await mockIntervalService.findAllWithUsers(),
+        goals: await mockGoalService.findAll(),
+        currentUser: mockRequest.user,
+      });
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should update a user', async () => {
+      const mockRequest = {
+        user: { id: 1, role: 'admin' },
+      };
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      const updateUserDto = { email: 'new@email.com' };
+      const expectedResult = { id: 1, email: 'updated@email.com' };
+      await controller.updateUser(
+        '1',
+        updateUserDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+      expect(mockUserService.update).toHaveBeenCalledWith(1, updateUserDto);
+      expect(mockResponse.json).toHaveBeenCalledWith(expectedResult);
+    });
+
+    it('should throw ForbiddenException if user not found', async () => {
+      const mockRequest = {
+        user: { id: 1, role: 'admin' },
+      };
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      jest.spyOn(mockUserService, 'findById').mockResolvedValueOnce(null);
+
+      await expect(
+        controller.updateUser(
+          '1',
+          { email: 'new@email.com' },
+          mockRequest as any,
+          mockResponse as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('should delete a user', async () => {
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      await controller.deleteUser('1', mockResponse as any);
+
+      expect(mockUserService.delete).toHaveBeenCalledWith(1);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'User deleted successfully',
+      });
+    });
+  });
+
+  describe('createInterval', () => {
+    it('should create an interval', async () => {
+      const mockRequest = {};
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      const createIntervalDto = {
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      };
+
+      const expectedResult = {
+        id: 2,
+        startDate: createIntervalDto.startDate.toISOString(),
+        endDate: createIntervalDto.endDate.toISOString(),
+        userId: createIntervalDto.userId,
+      };
+
+      mockIntervalService.create = jest.fn().mockResolvedValue({
+        id: 2,
+        startDate: expectedResult.startDate,
+        endDate: expectedResult.endDate,
+        userId: expectedResult.userId,
+      });
+
+      await controller.createInterval(
+        createIntervalDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockIntervalService.create).toHaveBeenCalledWith(
+        createIntervalDto,
+      );
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expectedResult.id,
+          startDate: expectedResult.startDate,
+          endDate: expectedResult.endDate,
+          userId: expectedResult.userId,
+        }),
+      );
+    });
+  });
+
+  describe('deleteInterval', () => {
+    it('should delete an interval', async () => {
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      await controller.deleteInterval('1', mockResponse as any);
+
+      expect(mockIntervalService.delete).toHaveBeenCalledWith(1);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Interval deleted successfully',
+      });
+    });
+  });
+
+  describe('updateInterval', () => {
+    it('should update an interval', async () => {
+      const mockRequest = {};
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      const updateIntervalDto = {
+        startDate: new Date(),
+        endDate: new Date(),
+      };
+
+      const expectedResult = {
+        id: 1,
+        startDate: updateIntervalDto.startDate.toISOString(),
+        endDate: updateIntervalDto.endDate.toISOString(),
+        userId: 1,
+      };
+
+      mockIntervalService.update = jest.fn().mockResolvedValue({
+        id: 1,
+        startDate: expectedResult.startDate,
+        endDate: expectedResult.endDate,
+        userId: 1,
+      });
+
+      await controller.updateInterval(
+        '1',
+        updateIntervalDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockIntervalService.update).toHaveBeenCalledWith(
+        1,
+        updateIntervalDto,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expectedResult.id,
+          startDate: expectedResult.startDate,
+          endDate: expectedResult.endDate,
+          userId: expectedResult.userId,
+        }),
+      );
+    });
+
+    it('should throw ForbiddenException if interval not found', async () => {
+      const mockRequest = {};
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      jest.spyOn(mockIntervalService, 'findById').mockResolvedValueOnce(null);
+
+      await expect(
+        controller.updateInterval(
+          '1',
+          { startDate: new Date(), endDate: new Date() },
+          mockRequest as any,
+          mockResponse as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('createGoal', () => {
+    it('should create a goal', async () => {
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      const createGoalDto = {
+        intervalId: 1,
+        name: 'New Goal',
+      };
+
+      const expectedResult = {
+        id: 3,
+        name: createGoalDto.name,
+        intervalId: createGoalDto.intervalId,
+      };
+
+      await controller.createGoal(createGoalDto, mockResponse as any);
+
+      expect(mockGoalService.create).toHaveBeenCalledWith(createGoalDto);
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith(expectedResult);
+    });
+  });
+
+  describe('updateGoal', () => {
+    it('should update a goal', async () => {
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      const updateGoalDto = {
+        name: 'Updated Goal Name',
+      };
+
+      const expectedResult = {
+        id: 1,
+        name: updateGoalDto.name,
+        intervalId: 1,
+      };
+
+      mockGoalService.update = jest.fn().mockResolvedValue({
+        id: 1,
+        name: updateGoalDto.name,
+        intervalId: 1,
+      });
+
+      await controller.updateGoal('1', updateGoalDto, mockResponse as any);
+
+      expect(mockGoalService.update).toHaveBeenCalledWith(1, updateGoalDto);
+      expect(mockResponse.json).toHaveBeenCalledWith(expectedResult);
+    });
+
+    it('should return 404 if goal not found', async () => {
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      jest.spyOn(mockGoalService, 'findById').mockResolvedValueOnce(null);
+
+      await controller.updateGoal(
+        '1',
+        { name: 'Updated Goal Name' },
+        mockResponse as any,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Goal not found',
+      });
+    });
+  });
+
+  describe('deleteGoal', () => {
+    it('should delete a goal', async () => {
+      const mockResponse = {
+        json: jest.fn(),
+      };
+
+      await controller.deleteGoal('1', mockResponse as any);
+
+      expect(mockGoalService.delete).toHaveBeenCalledWith(1);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Goal deleted successfully',
+      });
+    });
+
+    it('should return 404 if goal not found', async () => {
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      jest.spyOn(mockGoalService, 'findById').mockResolvedValueOnce(null);
+
+      await controller.deleteGoal('1', mockResponse as any);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Goal not found',
+      });
+    });
+  });
+});

--- a/src/UI/profile.controller.spec.ts
+++ b/src/UI/profile.controller.spec.ts
@@ -1,0 +1,278 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfileController } from './profile.controller';
+import { UserService } from '../user/user.service';
+import { IntervalService } from '../interval/interval.service';
+import { GoalService } from '../goal/goal.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../roles/roles.guard';
+import { ForbiddenException } from '@nestjs/common';
+import { Interval } from '../entities/interval.entity';
+
+describe('ProfileController', () => {
+  let controller: ProfileController;
+  let mockUserService: Partial<UserService>;
+  let mockIntervalService: Partial<IntervalService>;
+  let mockGoalService: Partial<GoalService>;
+
+  beforeEach(async () => {
+    mockUserService = {
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        email: 'user1@email.com',
+        firstName: 'Test',
+        lastName: 'User',
+      }),
+      update: jest.fn().mockResolvedValue({
+        id: 1,
+        email: 'updated@email.com',
+        firstName: 'Updated',
+        lastName: 'User',
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockIntervalService = {
+      findByUserOrPublic: jest
+        .fn()
+        .mockResolvedValue([
+          { id: 1, startDate: new Date(), endDate: new Date(), userId: 1 },
+        ]),
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+      update: jest.fn().mockResolvedValue({
+        id: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({
+        id: 2,
+        startDate: new Date(),
+        endDate: new Date(),
+        userId: 1,
+      }),
+    };
+
+    mockGoalService = {
+      findByUserOrPublic: jest
+        .fn()
+        .mockResolvedValue([{ id: 1, name: 'Goal 1', intervalId: 1 }]),
+      findById: jest.fn().mockResolvedValue({
+        id: 1,
+        name: 'Goal 1',
+        intervalId: 1,
+      }),
+      update: jest.fn().mockResolvedValue({
+        id: 1,
+        name: 'Updated Goal',
+        intervalId: 1,
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockResolvedValue({
+        id: 3,
+        name: 'New Goal',
+        intervalId: 1,
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfileController],
+      providers: [
+        { provide: UserService, useValue: mockUserService },
+        { provide: IntervalService, useValue: mockIntervalService },
+        { provide: GoalService, useValue: mockGoalService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    controller = module.get<ProfileController>(ProfileController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getProfile', () => {
+    it('should return user profile data', async () => {
+      const mockResponse = { render: jest.fn() };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+
+      await controller.getProfile(mockResponse as any, mockRequest as any);
+
+      expect(mockResponse.render).toHaveBeenCalledWith('profile', {
+        user: await mockUserService.findById(1),
+        intervals: await mockIntervalService.findByUserOrPublic(1),
+        goals: await mockGoalService.findByUserOrPublic(1),
+        currentUser: mockRequest.user,
+      });
+    });
+
+    it('should throw ForbiddenException if user is not authenticated', async () => {
+      const mockResponse = { render: jest.fn() };
+      const mockRequest = { user: null };
+
+      await expect(
+        controller.getProfile(mockResponse as any, mockRequest as any),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('should update the user profile', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+      const updateUserDto = { email: 'new@email.com' };
+
+      await controller.updateProfile(
+        updateUserDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockUserService.update).toHaveBeenCalledWith(1, updateUserDto);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Profile updated successfully',
+        updatedUser: await mockUserService.update(1, updateUserDto),
+      });
+    });
+
+    it('should throw ForbiddenException if user is not authenticated', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: null };
+      const updateUserDto = { email: 'new@email.com' };
+
+      await expect(
+        controller.updateProfile(
+          updateUserDto,
+          mockRequest as any,
+          mockResponse as any,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleteProfile', () => {
+    it('should delete the user profile', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+
+      await controller.deleteProfile(mockRequest as any, mockResponse as any);
+
+      expect(mockUserService.delete).toHaveBeenCalledWith(1);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Profile deleted successfully',
+      });
+    });
+
+    it('should throw ForbiddenException if user is not authenticated', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: null };
+
+      await expect(
+        controller.deleteProfile(mockRequest as any, mockResponse as any),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('createInterval', () => {
+    it('should create an interval for the current user', async () => {
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+      const createIntervalDto = {
+        startDate: new Date(),
+        endDate: new Date(Date.now() + 3600 * 1000),
+      };
+
+      await controller.createInterval(
+        createIntervalDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockIntervalService.create).toHaveBeenCalledWith({
+        ...createIntervalDto,
+        userId: 1,
+        startDate: new Date(createIntervalDto.startDate),
+        endDate: new Date(createIntervalDto.endDate),
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        await mockIntervalService.create({
+          ...createIntervalDto,
+          userId: 1,
+        }),
+      );
+    });
+  });
+
+  describe('deleteInterval', () => {
+    it('should delete an interval if user has access', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+
+      await controller.deleteInterval(
+        '1',
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockIntervalService.delete).toHaveBeenCalledWith(1);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: 'Interval deleted successfully',
+      });
+    });
+
+    it('should throw ForbiddenException if interval does not belong to user', async () => {
+      const mockResponse = { json: jest.fn() };
+      const mockRequest = { user: { id: 2, role: 'user' } };
+
+      jest.spyOn(mockIntervalService, 'findById').mockResolvedValueOnce({
+        id: 1,
+        userId: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+        user: {},
+        goals: [],
+      } as Interval);
+
+      await expect(
+        controller.deleteInterval('1', mockRequest as any, mockResponse as any),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('createGoal', () => {
+    it('should create a goal if user has access to interval', async () => {
+      const mockResponse = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      const mockRequest = { user: { id: 1, role: 'user' } };
+      const createGoalDto = { intervalId: 1, name: 'New Goal' };
+
+      await controller.createGoal(
+        createGoalDto,
+        mockRequest as any,
+        mockResponse as any,
+      );
+
+      expect(mockGoalService.create).toHaveBeenCalledWith(createGoalDto);
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        await mockGoalService.create(createGoalDto),
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Overview
This pull request introduces unit test suites for the `DashboardController` and `ProfileController` enhancing the project's test coverage and ensuring the reliability of core features.

### Changes
1. **DashboardController Unit Tests**
   - Added `dashboard.controller.spec.ts`.
   - Covered all endpoints (`GET`, `PUT`, `DELETE` and `POST`).
   - Tested scenarios for user roles, authentication and resource management.

2. **ProfileController Unit Tests**
   - Added `profile.controller.spec.ts`.
   - Included tests for user profile management, intervals and goals.
   - Ensured proper error handling for authentication and authorization.

3. **Mocked Dependencies**
   - Mocked services (`UserService`, `IntervalService` and `GoalService`) to isolate controller logic.
   - Mocked guards (`JwtAuthGuard`and `RolesGuard`) to simulate authenticated requests.