### PR TITLE
Refactor Utils, Add Browserify Support and Update Dockerfile for Production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 RUN mkdir -p dist/public && cp -r public/* dist/public/
+RUN npx tsc src/utils/utils.ts --outDir dist/utils
+RUN npx browserify dist/utils/utils.js -o public/js/utils.bundle.js
 RUN npm run build
 EXPOSE 3000
 CMD ["node", "dist/main"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,10 +1640,24 @@
         }
       }
     },
+    "node_modules/@nestjs/cli/node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@nestjs/common": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.8.tgz",
-      "integrity": "sha512-PVor9dxihg3F2LMnVNkQu42vUmea2+qukkWXUSumtVKDsBo7X7jnZWXtF5bvNTcYK7IYL4/MM4awNfJVJcJpFg==",
+      "version": "10.4.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.11.tgz",
+      "integrity": "sha512-7MnKYckMsT/LGlwC0PCY8XZFWD84bxVwsPsn9H2RrLSbCCwUvcRb39ZkQt4uR+zKj2fq4TsV80+5DfjMwFvVdg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -1685,9 +1699,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.8.tgz",
-      "integrity": "sha512-Kdi9rDZdlCkGL2AK9XuJ24bZp2YFV6dWBdogGsAHSP5u95wfnSkhduxHZy6q/i1nFFiLASUHabL8Jwr+bmD22Q==",
+      "version": "10.4.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.11.tgz",
+      "integrity": "sha512-S8wbxl08SZ2dgLRrIJNpesxI8ppn3y50XW3hH3HvKfUSjMEmCNIcGvge3WxJULiYkOUnmZ3ZqJAmKr2EjAGliA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1755,9 +1769,9 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.8.tgz",
-      "integrity": "sha512-bDz6wQD9LzGeK6uAAFv9l9AbrpyPwHStNObL8J95HBAXJesOblVlQMBAhdfci1YVMQUfOc36qq0IpRSa1II9Mg==",
+      "version": "10.4.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.11.tgz",
+      "integrity": "sha512-YjhoIOdCbpxy3p5Em2pqYsUY+5cpyocguCzMI91qh41/jTAUzBD25K+hAiMyENZXEkDyscoF8OajyZvWm1ihdQ==",
       "license": "MIT",
       "dependencies": {
         "body-parser": "1.20.3",
@@ -1800,9 +1814,9 @@
       "license": "MIT"
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.8.tgz",
-      "integrity": "sha512-VusUnVgfY6KUc0gKU7ER9QQ2QyCoO770wcAfgLhtqydezt/w07FvqT6uOtb/Tf4SMfUbxx6AJwte6UUmkewbnQ==",
+      "version": "10.4.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.11.tgz",
+      "integrity": "sha512-jpZwVrPfOvjZxdYMHasHko38XD+yuGAGJBM3qFQlZRQkZ+mEa6AuXUcMXihXWehHw7DXTeYi7u2hA+HN/wBBbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2071,12 +2085,12 @@
       }
     },
     "node_modules/@types/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
+      "integrity": "sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@types/express": "*"
       }
     },
@@ -2137,9 +2151,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.1.tgz",
-      "integrity": "sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.2.tgz",
+      "integrity": "sha512-vluaspfvWEtE4vcSDlKRNer52DvOGrB2xv6diXy6UKyKW0lqZiWHGNApSyxOv+8DE5Z27IzVvE7hNkxg7EXIcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2236,9 +2250,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
-      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "version": "20.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
+      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2336,17 +2350,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
-      "integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.16.0.tgz",
+      "integrity": "sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.15.0",
-        "@typescript-eslint/type-utils": "8.15.0",
-        "@typescript-eslint/utils": "8.15.0",
-        "@typescript-eslint/visitor-keys": "8.15.0",
+        "@typescript-eslint/scope-manager": "8.16.0",
+        "@typescript-eslint/type-utils": "8.16.0",
+        "@typescript-eslint/utils": "8.16.0",
+        "@typescript-eslint/visitor-keys": "8.16.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -2370,16 +2384,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
-      "integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
+      "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.15.0",
-        "@typescript-eslint/types": "8.15.0",
-        "@typescript-eslint/typescript-estree": "8.15.0",
-        "@typescript-eslint/visitor-keys": "8.15.0",
+        "@typescript-eslint/scope-manager": "8.16.0",
+        "@typescript-eslint/types": "8.16.0",
+        "@typescript-eslint/typescript-estree": "8.16.0",
+        "@typescript-eslint/visitor-keys": "8.16.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2399,14 +2413,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
-      "integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
+      "integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.15.0",
-        "@typescript-eslint/visitor-keys": "8.15.0"
+        "@typescript-eslint/types": "8.16.0",
+        "@typescript-eslint/visitor-keys": "8.16.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2417,14 +2431,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
-      "integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.16.0.tgz",
+      "integrity": "sha512-IqZHGG+g1XCWX9NyqnI/0CX5LL8/18awQqmkZSl2ynn8F76j579dByc0jhfVSnSnhf7zv76mKBQv9HQFKvDCgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.15.0",
-        "@typescript-eslint/utils": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.16.0",
+        "@typescript-eslint/utils": "8.16.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2445,9 +2459,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
-      "integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
+      "integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2459,14 +2473,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
-      "integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
+      "integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.15.0",
-        "@typescript-eslint/visitor-keys": "8.15.0",
+        "@typescript-eslint/types": "8.16.0",
+        "@typescript-eslint/visitor-keys": "8.16.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2488,16 +2502,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
-      "integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
+      "integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.15.0",
-        "@typescript-eslint/types": "8.15.0",
-        "@typescript-eslint/typescript-estree": "8.15.0"
+        "@typescript-eslint/scope-manager": "8.16.0",
+        "@typescript-eslint/types": "8.16.0",
+        "@typescript-eslint/typescript-estree": "8.16.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2516,13 +2530,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
-      "integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
+      "integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/types": "8.16.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3031,9 +3045,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3461,9 +3475,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001683",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
-      "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
+      "version": "1.0.30001684",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+      "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
       "dev": true,
       "funding": [
         {
@@ -4286,9 +4300,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.63",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.63.tgz",
-      "integrity": "sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==",
+      "version": "1.5.66",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.66.tgz",
+      "integrity": "sha512-pI2QF6+i+zjPbqRzJwkMvtvkdI7MjVbSh2g8dlMguDJIXEPw+kwasS1Jl+YGPEBfGVxsVgGUratAKymPdPo2vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8068,9 +8082,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9422,9 +9436,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
-      "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.2.tgz",
+      "integrity": "sha512-ZF5gQIQa/UmzfvxbHZI3JXN0/Jt+vnAfAviNRAMc491laiK6YCLpCW9ft8oaCRFOTxCZtUTE6XB0ZQAe3olntw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9796,9 +9810,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -308,7 +308,7 @@ form.profile-form input.profile-error {
   background-color: #ffe6e6;
 }
 
-#loading-overlay, #loading-profile-overlay {
+.loading-overlay {
   display: none;
   position: fixed;
   top: 0;

--- a/public/js/utils.bundle.js
+++ b/public/js/utils.bundle.js
@@ -1,0 +1,159 @@
+(function () {
+  function r(e, n, t) {
+    function o(i, f) {
+      if (!n[i]) {
+        if (!e[i]) {
+          var c = 'function' == typeof require && require;
+          if (!f && c) return c(i, !0);
+          if (u) return u(i, !0);
+          var a = new Error("Cannot find module '" + i + "'");
+          throw ((a.code = 'MODULE_NOT_FOUND'), a);
+        }
+        var p = (n[i] = { exports: {} });
+        e[i][0].call(
+          p.exports,
+          function (r) {
+            var n = e[i][1][r];
+            return o(n || r);
+          },
+          p,
+          p.exports,
+          r,
+          e,
+          n,
+          t,
+        );
+      }
+      return n[i].exports;
+    }
+    for (
+      var u = 'function' == typeof require && require, i = 0;
+      i < t.length;
+      i++
+    )
+      o(t[i]);
+    return o;
+  }
+  return r;
+})()(
+  {
+    1: [
+      function (require, module, exports) {
+        'use strict';
+        Object.defineProperty(exports, '__esModule', { value: true });
+        exports.showErrorMessage = showErrorMessage;
+        exports.showSuccessMessage = showSuccessMessage;
+        exports.getAssociatedForm = getAssociatedForm;
+        exports.showLoading = showLoading;
+        exports.hideLoading = hideLoading;
+        exports.disableUI = disableUI;
+        exports.enableUI = enableUI;
+        function showErrorMessage(element, message) {
+          element.textContent = message;
+          element.style.display = 'inline';
+          setTimeout(function () {
+            element.style.display = 'none';
+            element.textContent = '';
+          }, 5000);
+        }
+        function showSuccessMessage(element, message) {
+          element.textContent = message;
+          element.style.display = 'inline';
+          setTimeout(function () {
+            element.style.display = 'none';
+            element.textContent = '';
+          }, 5000);
+        }
+        function getAssociatedForm(button) {
+          var type = button.getAttribute('data-type');
+          var form = null;
+          if (type === 'user') {
+            var userId = button.getAttribute('data-user-id');
+            form = document.querySelector(
+              '.update-user-form[data-user-id="'.concat(userId, '"]'),
+            );
+          } else if (type === 'interval') {
+            var intervalId = button.getAttribute('data-interval-id');
+            form = document.querySelector(
+              '.update-interval-form[data-interval-id="'.concat(
+                intervalId,
+                '"]',
+              ),
+            );
+          } else if (type === 'goal') {
+            var goalId = button.getAttribute('data-goal-id');
+            form = document.querySelector(
+              '.update-goal-form[data-goal-id="'.concat(goalId, '"]'),
+            );
+          }
+          if (form && form instanceof HTMLElement) {
+            return form;
+          }
+          console.warn('No form found for this button.');
+          return null;
+        }
+        function showLoading(message) {
+          if (message === void 0) {
+            message = 'Loading...';
+          }
+          var loadingOverlay = document.querySelector('.loading-overlay');
+          if (loadingOverlay) {
+            loadingOverlay.textContent = message;
+            loadingOverlay.style.display = 'flex';
+          } else {
+            console.warn('No loading overlay found.');
+          }
+        }
+        function hideLoading(delay) {
+          if (delay === void 0) {
+            delay = 2000;
+          }
+          var loadingOverlay = document.querySelector('.loading-overlay');
+          if (loadingOverlay) {
+            setTimeout(function () {
+              loadingOverlay.style.display = 'none';
+            }, delay);
+          } else {
+            console.warn('No loading overlay found.');
+          }
+        }
+        function disableUI() {
+          var elements = document.querySelectorAll('button, input, select');
+          elements.forEach(function (element) {
+            if (
+              element instanceof HTMLButtonElement ||
+              element instanceof HTMLInputElement ||
+              element instanceof HTMLSelectElement
+            ) {
+              element.disabled = true;
+            }
+          });
+        }
+        function enableUI() {
+          var elements = document.querySelectorAll('button, input, select');
+          elements.forEach(function (element) {
+            if (
+              element instanceof HTMLButtonElement ||
+              element instanceof HTMLInputElement ||
+              element instanceof HTMLSelectElement
+            ) {
+              element.disabled = false;
+            }
+          });
+        }
+        if (typeof window !== 'undefined') {
+          window.showErrorMessage = showErrorMessage;
+          window.showSuccessMessage = showSuccessMessage;
+          window.getAssociatedForm = getAssociatedForm;
+          window.showLoading = showLoading;
+          window.hideLoading = hideLoading;
+          window.disableUI = disableUI;
+          window.enableUI = enableUI;
+        }
+      },
+      {},
+    ],
+  },
+  {},
+  [1],
+);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,129 @@
+function showErrorMessage(element, message) {
+  element.textContent = message;
+  element.style.display = 'inline';
+  setTimeout(() => {
+    element.style.display = 'none';
+    element.textContent = '';
+  }, 5000);
+}
+function showSuccessMessage(element, message) {
+  element.textContent = message;
+  element.style.display = 'inline';
+  setTimeout(() => {
+    element.style.display = 'none';
+    element.textContent = '';
+  }, 5000);
+}
+
+function getAssociatedForm(button: HTMLElement): HTMLElement | null {
+  const type = button.getAttribute('data-type');
+
+  let form: Element | null = null;
+
+  if (type === 'user') {
+    const userId = button.getAttribute('data-user-id');
+    form = document.querySelector(
+      `.update-user-form[data-user-id="${userId}"]`,
+    );
+  } else if (type === 'interval') {
+    const intervalId = button.getAttribute('data-interval-id');
+    form = document.querySelector(
+      `.update-interval-form[data-interval-id="${intervalId}"]`,
+    );
+  } else if (type === 'goal') {
+    const goalId = button.getAttribute('data-goal-id');
+    form = document.querySelector(
+      `.update-goal-form[data-goal-id="${goalId}"]`,
+    );
+  }
+
+  if (form && form instanceof HTMLElement) {
+    return form;
+  }
+
+  console.warn('No form found for this button.');
+  return null;
+}
+
+function showLoading(message = 'Loading...') {
+  const loadingOverlay = document.querySelector(
+    '.loading-overlay',
+  ) as HTMLElement | null;
+  if (loadingOverlay) {
+    loadingOverlay.textContent = message;
+    loadingOverlay.style.display = 'flex';
+  } else {
+    console.warn('No loading overlay found.');
+  }
+}
+
+function hideLoading(delay = 2000) {
+  const loadingOverlay = document.querySelector(
+    '.loading-overlay',
+  ) as HTMLElement | null;
+  if (loadingOverlay) {
+    setTimeout(() => {
+      loadingOverlay.style.display = 'none';
+    }, delay);
+  } else {
+    console.warn('No loading overlay found.');
+  }
+}
+
+function disableUI() {
+  const elements = document.querySelectorAll('button, input, select');
+  elements.forEach((element) => {
+    if (
+      element instanceof HTMLButtonElement ||
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement
+    ) {
+      element.disabled = true;
+    }
+  });
+}
+
+function enableUI() {
+  const elements = document.querySelectorAll('button, input, select');
+  elements.forEach((element) => {
+    if (
+      element instanceof HTMLButtonElement ||
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement
+    ) {
+      element.disabled = false;
+    }
+  });
+}
+
+declare global {
+  interface Window {
+    showErrorMessage: (element: HTMLElement, message: string) => void;
+    showSuccessMessage: (element: HTMLElement, message: string) => void;
+    getAssociatedForm: (button: HTMLElement) => HTMLElement | null;
+    showLoading: (message?: string) => void;
+    hideLoading: (delay?: number) => void;
+    disableUI: () => void;
+    enableUI: () => void;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.showErrorMessage = showErrorMessage;
+  window.showSuccessMessage = showSuccessMessage;
+  window.getAssociatedForm = getAssociatedForm;
+  window.showLoading = showLoading;
+  window.hideLoading = hideLoading;
+  window.disableUI = disableUI;
+  window.enableUI = enableUI;
+}
+
+export {
+  showErrorMessage,
+  showSuccessMessage,
+  getAssociatedForm,
+  showLoading,
+  hideLoading,
+  disableUI,
+  enableUI,
+};

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -124,61 +124,8 @@
     </section>
   </main>
 
+  <script src="/js/utils.bundle.js"></script>
   <script>
-    function showErrorMessage(element, message) {
-      element.textContent = message;
-      element.style.display = 'inline';
-      setTimeout(() => {
-        element.style.display = 'none';
-        element.textContent = '';
-      }, 5000);
-    }
-    function showSuccessMessage(element, message) {
-      element.textContent = message;
-      element.style.display = 'inline';
-      setTimeout(() => {
-        element.style.display = 'none';
-        element.textContent = '';
-      }, 5000);
-    }
-    function getAssociatedForm(button) {
-      const type = button.getAttribute('data-type');
-
-      if (type === 'user') {
-        const userId = button.getAttribute('data-user-id');
-        return document.querySelector(`.update-user-form[data-user-id="${userId}"]`);
-      } else if (type === 'interval') {
-        const intervalId = button.getAttribute('data-interval-id');
-        return document.querySelector(`.update-interval-form[data-interval-id="${intervalId}"]`);
-      } else if (type === 'goal') {
-        const goalId = button.getAttribute('data-goal-id');
-        return document.querySelector(`.update-goal-form[data-goal-id="${goalId}"]`);
-      }
-
-      console.warn('No form found for this button.');
-      return null;
-    }
-    function showLoading(message = "Loading...") {
-      const loadingOverlay = document.getElementById('loading-overlay');
-      loadingOverlay.textContent = message;
-      loadingOverlay.style.display = 'flex';
-    }
-    function hideLoading(delay = 2000) {
-      const loadingOverlay = document.getElementById('loading-overlay');
-      setTimeout(() => {
-        loadingOverlay.style.display = 'none';
-      }, delay);
-    }
-    function disableUI() {
-      document.querySelectorAll('button, input, select').forEach(element => {
-        element.disabled = true;
-      });
-    }
-    function enableUI() {
-      document.querySelectorAll('button, input, select').forEach(element => {
-        element.disabled = false;
-      });
-    }
       document.addEventListener('DOMContentLoaded', function() {
         hideLoading();
         const deleteUserButtons = document.querySelectorAll('.delete-user-btn');
@@ -502,7 +449,7 @@
       });
   </script>
   <%- include('partials/footer') %>
-  <div id="loading-overlay">
+  <div class="loading-overlay">
     Loading...
   </div>
 </body>

--- a/src/views/profile.ejs
+++ b/src/views/profile.ejs
@@ -114,65 +114,8 @@
     <span id="delete-profile-success" class="success-message" style="color: green; display: none;"></span>
   </main>
 
+  <script src="/js/utils.bundle.js"></script>
   <script>
-    function showErrorMessage(element, message) {
-      element.textContent = message;
-      element.style.display = 'inline';
-      setTimeout(() => {
-        element.style.display = 'none';
-        element.textContent = '';
-      }, 5000);
-    }
-
-    function showSuccessMessage(element, message) {
-      element.textContent = message;
-      element.style.display = 'inline';
-      setTimeout(() => {
-        element.style.display = 'none';
-        element.textContent = '';
-      }, 5000);
-    }
-
-    function getAssociatedForm(button) {
-      const type = button.getAttribute('data-type');
-
-      if (type === 'user') {
-        const userId = button.getAttribute('data-user-id');
-        return document.querySelector(`.update-user-form[data-user-id="${userId}"]`);
-      } else if (type === 'interval') {
-        const intervalId = button.getAttribute('data-interval-id');
-        return document.querySelector(`.update-interval-form[data-interval-id="${intervalId}"]`);
-      } else if (type === 'goal') {
-        const goalId = button.getAttribute('data-goal-id');
-        return document.querySelector(`.update-goal-form[data-goal-id="${goalId}"]`);
-      }
-
-      console.warn('No form found for this button.');
-      return null;
-      }
-      
-      function showLoading(message = "Loading...") {
-        const loadingOverlay = document.getElementById('loading-profile-overlay');
-        loadingOverlay.textContent = message;
-        loadingOverlay.style.display = 'flex';
-      }
-      function hideLoading(delay = 2000) {
-        const loadingOverlay = document.getElementById('loading-profile-overlay');
-        setTimeout(() => {
-          loadingOverlay.style.display = 'none';
-        }, delay);
-      }
-      function disableUI() {
-        document.querySelectorAll('button, input, select').forEach(element => {
-          element.disabled = true;
-        });
-      }
-      function enableUI() {
-        document.querySelectorAll('button, input, select').forEach(element => {
-          element.disabled = false;
-        });
-      }
-
       document.addEventListener('DOMContentLoaded', function() {
         hideLoading();
         const updateUserForm = document.querySelector('.update-user-form');
@@ -499,7 +442,7 @@
         })
   </script>
   <%- include('partials/footer') %>
-  <div id="loading-profile-overlay">
+  <div class="loading-overlay">
     Loading...
   </div>
 </body>


### PR DESCRIPTION
This pull request introduces the following key changes:
	1.	Refactor and Centralization of Utility Functions:
	•	Shared utility functions (e.g., showErrorMessage, showSuccessMessage, getAssociatedForm, etc.) used across dashboard and profile views have been centralized in a new file: src/utils/utils.ts.
	•	This refactor improves maintainability and fosters better reusability across the project.
	2.	Integration of Browserify for TypeScript and CommonJS Support:
	•	Utility functions are now bundled into a single file (public/js/utils.bundle.js) using Browserify. This ensures compatibility with the browser while retaining the benefits of TypeScript and CommonJS module syntax.
	•	Commands added to the workflow:
	•	npx tsc src/utils/utils.ts --outDir dist/utils
	•	npx browserify dist/utils/utils.js -o public/js/utils.bundle.js
	3.	Dockerfile Update for Production:
	•	Added steps in the Dockerfile to:
	•	Compile utils.ts to JavaScript using TypeScript (npx tsc).
	•	Generate the browser-compatible bundle with Browserify during the build process.
	•	Ensured that utils.bundle.js is correctly placed in the public/js directory for static asset serving in production.
	•	Maintained the existing production setup for serving views, static assets and REST API functionality.

Modified Files:

	1.	src/utils/utils.ts: Created to centralize and refactor utility functions.
	2.	public/js/utils.bundle.js: Generated browser-compatible bundle for utility functions.
	3.	Dockerfile: Updated with TypeScript and Browserify build steps for production.

Why These Changes?

	•	Maintainability: Centralizing utility functions reduces duplication and enhances clarity across the codebase.
	•	Browser Compatibility: Using Browserify ensures that TypeScript-based modules are compatible with the browser while leveraging CommonJS.
	•	Production-Readiness: The Dockerfile update ensures a seamless production build including all necessary assets and bundles.